### PR TITLE
Update llama2 readme

### DIFF
--- a/vllm/models/Llama2/README.md
+++ b/vllm/models/Llama2/README.md
@@ -21,9 +21,9 @@ mkdir -p /data/mtt/models /data/mtt/models_convert
 # 2. clone model
 cd /data/mtt/models
 git lfs install
-git clone https://www.modelscope.cn/shakechen/Llama-2-7b-hf.git
-# git clone https://www.modelscope.cn/ydyajyA/Llama-2-13b-hf.git
-# git clone https://www.modelscope.cn/AI-ModelScope/Llama-2-70b-hf.git
+git clone https://www.modelscope.cn/shakechen/Llama-2-7b-chat-hf.git
+# git clone https://www.modelscope.cn/ydyajyA/Llama-2-13b-chat-hf.git
+# git clone https://www.modelscope.cn/AI-ModelScope/Llama-2-70b-chat-hf.git
 ```
 > If you encounter any issues while downloading the model, please refer to the [README](../../../llama.cpp/README.md).
 ### 2.3 Weight Conversion


### PR DESCRIPTION
kaue1.3下 llama2不带chat的模型会报错，修改为chat模型