### PR TITLE
fix(pytorch): del py39 torch_musa image

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -21,7 +21,7 @@ mthreads-gmi
 
 </details> 
 
-**NOTE: Python3.9和Python3.10请分别使用“py39”和“py310”替换上述镜像中“py38”.**
+**NOTE: Python3.10 版本镜像请使用 `py310` 替换上述镜像 tag 中 `py38`.**
 
 **请按照实际驱动环境，参考上述表格，更换启动docker命令中镜像名**
 ```bash
@@ -32,6 +32,6 @@ docker run -it --privileged --pull always --network=host --name=torch_musa_test 
 # 容器环境检查
 ```
 # 在容器内执行
-cd examples_on_musa/setup_musa/check
+cd tutorial_on_musa/setup_musa/check
 bash test_musa.sh
 ```


### PR DESCRIPTION
1. S80-py39和S4000-py39 镜像环境均有相同问题，S3000-py39 未验证
![image](https://github.com/user-attachments/assets/756d931d-8934-425f-baa3-9b55ca177afe)
![04000520b42381654c1c9a8134b7ea29](https://github.com/user-attachments/assets/ca92c3b3-e4cc-4279-acec-cf1cbabb6968)
